### PR TITLE
Doc parser: allow passing the output filename as a command-line argument,

### DIFF
--- a/docs/parse.php
+++ b/docs/parse.php
@@ -11,7 +11,7 @@
     ? $_SERVER['argv'][1] : basename($file);
   /*--------------------------------------------------------------------------*/
 
-  require('../vendor/docdown/docdown.php');
+  require('../docdown.php');
 
   // generate Markdown
   $markdown = docdown(array(


### PR DESCRIPTION
Doc parser: allow passing the output filename as a command-line argument, e.g.

``` bash
php -f parse.php README
```
