### PR TITLE
fixing undefined / sorting, with category and no methods

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -261,16 +261,18 @@ function generateDoc(source, options) {
       '## `' + group + '`'
     );
 
-    // Sort the TOC groups.
-    organized[group].sort(function(value, other) {
-      var valMember = value.getMembers(0),
-          othMember = other.getMembers(0);
-
-      return utils.compareNatural(
-        (valMember ? (valMember + getSeparator(value)) : '') + value.getName(),
-        (othMember ? (othMember + getSeparator(other)) : '') + other.getName()
-      );
-    });
+    if (organized[group]) {
+      // Sort the TOC groups.
+      organized[group].sort(function(value, other) {
+        var valMember = value.getMembers(0),
+            othMember = other.getMembers(0);
+  
+        return utils.compareNatural(
+          (valMember ? (valMember + getSeparator(value)) : '') + value.getName(),
+          (othMember ? (othMember + getSeparator(other)) : '') + other.getName()
+        );
+      });
+    }
 
     // Add TOC entries for each category.
     _.each(organized[group], function(entry) {


### PR DESCRIPTION
If you sort by category and you have no methods, you'll get a `Cannot read property 'sort' of undefined` because it will try to sort the methods category.