### PR TITLE
Fix path and url check

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function docdown(options) {
     'toc': 'properties'
   });
 
-  if (!options.path || !options.url) {
+  if (!options.path && !options.url) {
     throw new Error('Path and/or URL must be specified');
   }
   return generator(fs.readFileSync(options.path, 'utf8'), options);


### PR DESCRIPTION
Otherwise, the lib throws an error even when a path is specified.

```sh
$ docdown index.js index.md 

node_modules/docdown/index.js:29
    throw new Error('Path and/or URL must be specified');
          ^
Error: Path and/or URL must be specified
    at docdown (node_modules/docdown/index.js:29:11)
    at Object.<anonymous> (node_modules/docdown/bin/docdown:90:14)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```