### PR TITLE
Only list special categories in TOC if used

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -262,11 +262,12 @@ function generateDoc(source, options) {
   var tocGroups = _.keys(organized);
   if (byCategories) {
     // Remove special categories.
-    _.pull.apply(_, [tocGroups].concat(specialCategories));
+    var specialCatogoriesInUse = _.intersection(tocGroups, specialCategories);
+    _.pull.apply(_, [tocGroups].concat(specialCatogoriesInUse));
 
     // Sort categories and append special categories.
     if (sortEntries) tocGroups.sort(util.compareNatural);
-    push.apply(tocGroups, specialCategories);
+    push.apply(tocGroups, specialCatogoriesInUse);
   }
   else {
     tocGroups.sort(util.compareNatural);


### PR DESCRIPTION
Previously, if `options.toc` was set to 'categories', the special categories ('Methods' and 'Properties') were both added to the TOC even when there were no entries for either or both of these categories, as shown in the following output:
```markdown
## `Methods`

<!-- /div -->

<!-- div -->

## `Properties`

<!-- /div -->

<!-- /div -->

<!-- div class="doc-container" -->
```