### PR TITLE
Fix unextracted '@param' when last tag in block

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -360,7 +360,7 @@ function getName() {
 function getParams(index) {
   if (this._params === undefined) {
     var match,
-        re = /@param\s+\{\(?([^})]+)\)?\}\s+(\[.+\]|[\w]+(?:\[.+\])?)\s+([\s\S]*?)(?=\@)/gim,
+        re = /@param\s+\{\(?([^})]+)\)?\}\s+(\[.+\]|[\w]+(?:\[.+\])?)\s+([\s\S]*?)(?=\@|\*\/)/gim,
         result = [];
 
     while (match = re.exec(this.entry)) {


### PR DESCRIPTION
Previously, when the last tag in a comment block was '@param', that tag was not extracted and consequently excluded from the final output.