### PR TITLE
Add option for alphabetic sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function docdown(options) {
     'hash': 'default',
     'lang': 'js',
     'title': path.basename(options.path) + ' API documentation',
+    'sort': true,
     'toc': 'properties'
   });
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -127,6 +127,7 @@ function generateDoc(source, options) {
       entries = getEntries(source),
       hashStyle = options.hash,
       organized = {},
+      sortEntries = options.sort,
       url = options.url;
 
   // Add entries and aliases to the API list.
@@ -264,7 +265,7 @@ function generateDoc(source, options) {
     _.pull.apply(_, [tocGroups].concat(specialCategories));
 
     // Sort categories and append special categories.
-    tocGroups.sort(util.compareNatural);
+    if (sortEntries) tocGroups.sort(util.compareNatural);
     push.apply(tocGroups, specialCategories);
   }
   else {
@@ -278,7 +279,7 @@ function generateDoc(source, options) {
       '## `' + group + '`'
     );
 
-    if (organized[group]) {
+    if (sortEntries && organized[group]) {
       // Sort the TOC groups.
       organized[group].sort(function(value, other) {
         var valMember = value.getMembers(0),


### PR DESCRIPTION
Adds `options.sort` to `docdown(options)`. If `options.sort` is `true`,
then the methods (and categories, if enabled) are sorted alphabetically
in the documentation. If `false`, then methods (and categories) are
ordered as they appear in source. Defaults to `true`.

Fixes: #3

This does not alter the current behavior because `options.sort` defaults
to `true`.