### PR TITLE
Fix missing parens in params with ending parens

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -360,7 +360,7 @@ function getName() {
 function getParams(index) {
   if (this._params === undefined) {
     var match,
-        re = /@param\s+\{\(?([^})]+)\)?\}\s+(\[.+\]|[\w]+(?:\[.+\])?)\s+([\s\S]*?)(?=\@|\*\/)/gim,
+        re = /@param\s+\{\(?([^}]+)\)?\}\s+(\[.+\]|[\w]+(?:\[.+\])?)\s+([\s\S]*?)(?=\@|\*\/)/gim,
         result = [];
 
     while (match = re.exec(this.entry)) {


### PR DESCRIPTION
Fix missing parens in params with ending parens. See for instance [Lodash's `pullAt`](https://lodash.com/docs#pullAt), where the second param is described as *(…(number|number[])*: its missing a closing parens.

I simply removed a closing parens in the regex in `getParams`, which fixes the problem in the `pullAt` example. **Please be aware** that I don't know what else this could break by doing this (there are no tests to compare it to and I'm not that accustomed to JSDoc conventions).

You can try it out briefly [here](https://regex101.com/r/bV5iC7/1), and compare it to the [old version](https://regex101.com/r/iL7mZ4/2).

The problem is not totally fixed, since when it then gets generated to Markdown, the last closing parens is not italicized. I haven't figured out a fix to this yet, but I'm pretty sure it's linked to [this line](https://github.com/jdalton/docdown/blob/master/lib/generator.js#L84). I prepared [this](https://regex101.com/r/kM1pL6/1) if someone wants to have a go at it.