### PR TITLE
standardise line endings before processing string

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -94,6 +94,9 @@ function makeAnchor(href, text) {
  * @returns {string} Returns the documentation markdown.
  */
 function generateDoc(source, options) {
+  
+  source = source.replace(/\r\n|\r/g, '\n');
+  
   var api = [],
       byCategories = options.toc == 'categories',
       entries = getEntries(source),


### PR DESCRIPTION
Closes #42.

Windows line endings are removed before any processing happens.