### PR TITLE
Adds newline after h3 for github styling. Fixes #46

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -177,19 +177,26 @@ function generateDoc(source, options) {
 
     // Add the heading.
     entryMarkdown.push(interpolate(
-      '<h3 id="${hash}">${entryLink}<code>${member}${separator}${call}</code></h3>\n' +
-      interpolate(
-        _([
-          '${sourceLink}',
-          _.get(options, 'sublinks', []),
-          '${tocLink}'
-        ])
-        .flatten()
-        .compact()
-        .join(' '),
-        entryData
-      )
-      .replace(/ {2,}/g, ' '),
+      '<h3 id="${hash}">${entryLink}<code>${member}${separator}${call}</code></h3>'.replace(/ {2,}/g, ' '),
+      entryData
+    ));
+
+    // Github won't render the links correctly when preceeded by an html element,
+    // so we force an extra newline (newline comes from entryMarkdown.join())
+    if (options.style === 'github') {
+        entryMarkdown.push('');
+    }
+
+    // Add the heading.
+    entryMarkdown.push(interpolate(
+      _([
+        '${sourceLink}',
+        _.get(options, 'sublinks', []),
+        '${tocLink}'
+      ])
+      .flatten()
+      .compact()
+      .join(' '),
       entryData
     ));
 


### PR DESCRIPTION
As noted in the issue, github fails to render view source links correctly when preceded by an html element. The only solution I'm aware of is to force an empty line between them. Luckily, that line is not rendered:

<h3 id="addnodenode"><code>addNode(node)</code></h3>

[&#x24C8;](https://github.com/helion3/inspire-tree/blob/master/src/tree.js#L198 "View in source") [&#x24C9;][1]

Because the `entryMarkdown` array joins with `\n` and `\n\n` is converted into `<br><br>`, this solution appends an empty string (which gets converted into an empty newline). It not the nicest code but it anything else would involve potentially breaking changes to the format method.

Since the `h3` and line of links are now separate elements, the h3 no longer needed a hard-coded `\n`. However, I wasn't sure which text you intended the `.replace(/ {2,}/g, ' ')` to apply to so I guessed.