### PR TITLE
Fix issue #50

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -97,7 +97,7 @@ function generateDoc(source, options) {
   var api = [],
       byCategories = options.toc == 'categories',
       entries = getEntries(source),
-      organized = {},
+      organized = Object.create(null),
       sortEntries = options.sort,
       style = options.style,
       url = options.url;


### PR DESCRIPTION
Using `organized` as a Key/Value store is causing a conflict when the parser attempts to assign a value to `organized.constructor`.

This can be fixed by preventing `organized` from inheriting from Object.

ref: #50 